### PR TITLE
Follow :h background behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,19 +36,11 @@ Plug 'Mofiqul/adwaita.nvim'
 
 ```lua
 -- Lua:
--- For dark theme
-vim.g.adwaita_mode = "dark"
--- For light theme
-vim.g.adwaita_mode = "light"
 vim.cmd([[colorscheme adwaita]])
 ```
 
 ```vim
 " Vim-Script:
-" For dark theme
-let g:adwaita_mode = "dark"
-" For light theme
-let g:adwaita_mode = "light"
 colorscheme adwaita
 ```
 

--- a/colors/adwaita.lua
+++ b/colors/adwaita.lua
@@ -4,16 +4,14 @@ local adwaita_light = require'adwaita.light'
 vim.cmd("hi clear")
 
 if vim.fn.exists("syntax_on") then
-	vim.cmd("syntax reset")
+  vim.cmd("syntax reset")
 end
 
 vim.o.termguicolors = true
 vim.g.colors_name = "adwaita"
 
-if vim.g.adwaita_mode == 'dark' then
-    vim.o.background = "dark"
+if vim.o.background == 'dark' then
     adwaita_dark.set()
 else
-    vim.o.background = "light"
     adwaita_light.set()
 end

--- a/lua/lualine/themes/adwaita.lua
+++ b/lua/lualine/themes/adwaita.lua
@@ -3,7 +3,7 @@
 local adwaita = {}
 local colors = {}
 
-if vim.g.adwaita_mode == 'dark' then
+if vim.o.background == 'dark' then
     colors.bg = '#303030'
     colors.fg = '#DEDDDA'
 else


### PR DESCRIPTION
Specifically:

> When a color scheme is loaded (the "g:colors_name" variable is set)
> setting 'background' will cause the color scheme to be reloaded.

I haven't yet met a real need to set background option in a color scheme.
If it only implements one version, it will just display it. If it implements both, reading `vim.o.background` and following it is sufficient. Changing background will reload color scheme:

https://user-images.githubusercontent.com/314453/162332569-5cbba801-94ad-46fa-a258-7f0af28eb3ec.mp4