### PR TITLE
Make ColorColumn visible in dark theme

### DIFF
--- a/lua/adwaita/dark.lua
+++ b/lua/adwaita/dark.lua
@@ -74,7 +74,7 @@ local M = {}
 
 M.set = function ()
     highlight('Normal',                        colors.light_4,             colors.libadwaita_dark,     'none',      'none' )
-    highlight('ColorColumn',                   'none',                     colors.libadwaita_dark,     'none',      'none' )
+    highlight('ColorColumn',                   'none',                     colors.libadwaita_dark_alt, 'none',      'none' )
     highlight('Cursor',                        colors.light_5,             colors.libadwaita_dark,     'none',      'none' )
     highlight('CursorLine',                    'none',                     colors.libadwaita_dark_alt, 'none',      'none' )
     highlight('CursorColumn',                  'none',                     colors.libadwaita_dark_alt, 'none',      'none' )


### PR DESCRIPTION
Thank you for creating the theme :+1: 
On my machine, the colorcolumn was not really visible, except for places where there is text. 
![Screenshot from 2022-04-14 16-29-01](https://user-images.githubusercontent.com/183212/163412824-b1050147-0452-4003-a7a2-b465ba578f62.png) (where the cursor is)

The reason being that the "color" was set to the same as the background.
This changes the color to the "alt" dark color, creating this subtle highlight:
![Screenshot from 2022-04-14 16-30-02](https://user-images.githubusercontent.com/183212/163413096-b740170f-4b1c-402b-a7b1-d2e577eec890.png)

