### PR TITLE
Fix :set background=dark

### DIFF
--- a/colors/adwaita.lua
+++ b/colors/adwaita.lua
@@ -1,6 +1,3 @@
-local adwaita_dark = require'adwaita.dark'
-local adwaita_light = require'adwaita.light'
-
 vim.cmd("hi clear")
 
 if vim.fn.exists("syntax_on") then
@@ -11,7 +8,9 @@ vim.o.termguicolors = true
 vim.g.colors_name = "adwaita"
 
 if vim.o.background == 'dark' then
+    local adwaita_dark = require'adwaita.dark'
     adwaita_dark.set()
 else
+    local adwaita_light = require'adwaita.light'
     adwaita_light.set()
 end


### PR DESCRIPTION
When `background` is set to `light` in config, and I set it to `dark` *after* starting Neovim, with `:set background=dark`, I get an error. The issue seems to be with the color `libadwaita_dark`, only defined in the `colors` table when `background=dark`. I think calling `adwaita_dark.set()` from `colors/adwaita.lua` doesn’t regenerate the `colors` table, so the value `libadwaita_dark` is `nil`.

This change seems to regenerate the table. I don’t know if this is the best way to do it, but it seems to fix the issue.