### PR TITLE
Fix git diff colors

### DIFF
--- a/lua/lualine/themes/adwaita.lua
+++ b/lua/lualine/themes/adwaita.lua
@@ -4,7 +4,7 @@ local u = require'adwaita.utils'
 local adwaita = {}
 local colors = {}
 
-colors = u.gen_colors() 
+colors = u.gen_colors()
 
 
 local bg = vim.o.background == 'dark' and colors.libadwaita_dark_alt or colors.light_3
@@ -13,13 +13,13 @@ local fg = vim.o.background == 'dark' and colors.light_2 or colors.dark_3
 
 adwaita.normal = {
     a = { fg = bg, bg = colors.teal_5, gui = 'bold' },
-    b = { fg = bg, bg = colors.teal_2 },
+    b = { fg = colors.teal_2, bg = bg },
     c = { fg = fg, bg = bg },
 }
 
 adwaita.visual = {
     a = { fg = bg, bg = colors.blue_5, gui = 'bold' },
-    b = { fg = fg, bg = bg },
+    b = { fg = colors.blue_5, bg = bg },
 }
 
 adwaita.inactive = {
@@ -29,13 +29,13 @@ adwaita.inactive = {
 
 adwaita.replace = {
     a = { fg = bg, bg = colors.purple_4, gui = 'bold' },
-    b = { fg = bg, bg = colors.purple_2 },
+    b = { fg = colors.purple_2, bg = bg },
     c = { fg = fg, bg = bg },
 }
 
 adwaita.insert = {
     a = { fg = bg, bg = colors.orange_4, gui = 'bold' },
-    b = { fg = vim.o.background == 'dark' and bg or fg, bg = colors.orange_1 },
+    b = { fg = colors.orange_1, bg = vim.o.background == 'dark' and bg or fg },
     c = { fg = fg, bg = bg },
 }
 


### PR DESCRIPTION
This switches foreground and background colors in the "b" section of Lualine and produces a similar layout as with your `vscode.nvim`.

Section "b" of Lualine is used by default to display Git information. Git diffs information (red and green) were not easily readable on the colored backgrounds.