### PR TITLE
GitSigns: Adding support for linehighlights

### DIFF
--- a/lua/adwaita/dark.lua
+++ b/lua/adwaita/dark.lua
@@ -225,6 +225,9 @@ M.set = function()
     highlight('CocHighlightWrite', 'none', colors.blue_7, 'none', 'none')
 
     highlight('CmpItemKind', colors.light_4, 'none', 'none', 'none')
+
+    highlight('GitSignsAddLn', colors.green2, colors.green6, 'none', 'none')
+    highlight('GitSignsChangeLn', colors.orange_1, colors.orange_5, 'none', 'none')
     link_other_highlights()
 end
 

--- a/lua/adwaita/dark.lua
+++ b/lua/adwaita/dark.lua
@@ -226,7 +226,7 @@ M.set = function()
 
     highlight('CmpItemKind', colors.light_4, 'none', 'none', 'none')
 
-    highlight('GitSignsAddLn', colors.green2, colors.green6, 'none', 'none')
+    highlight('GitSignsAddLn', colors.green_2, colors.green_6, 'none', 'none')
     highlight('GitSignsChangeLn', colors.orange_1, colors.orange_5, 'none', 'none')
     link_other_highlights()
 end

--- a/lua/adwaita/light.lua
+++ b/lua/adwaita/light.lua
@@ -223,6 +223,9 @@ M.set = function()
     highlight('CocHighlightWrite', 'none', colors.blue_1, 'none', 'none')
 
     highlight('CmpItemKind', colors.dark_3, 'none', 'none', 'none')
+
+    highlight('GitSignsAddLn', colors.green_6, colors.green_2, 'none', 'none')
+    highlight('GitSignsChangeLn', colors.orange_5, colors.orange_1, 'none', 'none')
     link_other_highlights()
 end
 


### PR DESCRIPTION
Hi!
Thank you for this amazing theme!
I added support for GitSigns' LineHighlights (`:GitSigns toggle_linehl`).

Please review the implementation as I'm just getting started with Neovim, there may be a better way to implement this.

For instance, I noticed GitSigns can inherit colors from GitGutter and Diff, we should discuss if it would be better to support those directly and let GitSigns inherit them automatically (see https://github.com/lewis6991/gitsigns.nvim/blob/main/doc/gitsigns.txt#L473)

Anyway, here's some screenshots:

## Before:
![Screenshot from 2022-09-13 19-58-30](https://user-images.githubusercontent.com/36898760/189976179-33537e1d-74bc-4a2a-903f-751315701c3f.png)

![Screenshot from 2022-09-13 19-58-51](https://user-images.githubusercontent.com/36898760/189976203-528eae00-081b-4615-bb6e-4837073716da.png)

## After:

![Screenshot from 2022-09-13 19-45-42](https://user-images.githubusercontent.com/36898760/189975482-69e09437-e417-4f66-a416-a5e54efdccc7.png)

![Screenshot from 2022-09-13 19-45-59](https://user-images.githubusercontent.com/36898760/189975516-31e12a62-4d00-49a1-bbe2-7776a45e2fff.png)

