### PR TITLE
GitSigns: Adding support for GitSignsCurrentLineBlame and CursorLine

### DIFF
--- a/lua/adwaita/dark.lua
+++ b/lua/adwaita/dark.lua
@@ -264,6 +264,8 @@ M.set = function()
 
     hl('GitSignsAddLn', { fg = colors.green_2, bg = colors.green_6 })
     hl('GitSignsChangeLn', { fg = colors.orange_1, bg = colors.orange_5 })
+
+    hl("GitSignsCurrentLineBlame", { fg = colors.dark_2 })
 end
 
 

--- a/lua/adwaita/dark.lua
+++ b/lua/adwaita/dark.lua
@@ -264,8 +264,8 @@ M.set = function()
 
     hl('GitSignsAddLn', { fg = colors.green_2, bg = colors.green_6 })
     hl('GitSignsChangeLn', { fg = colors.orange_1, bg = colors.orange_5 })
-
     hl("GitSignsCurrentLineBlame", { fg = colors.dark_2 })
+
 end
 
 

--- a/lua/adwaita/light.lua
+++ b/lua/adwaita/light.lua
@@ -223,7 +223,6 @@ M.set = function()
 
     highlight('GitSignsAddLn', colors.green_6, colors.green_2, 'none', 'none')
     highlight('GitSignsChangeLn', colors.orange_5, colors.orange_1, 'none', 'none')
-
 	highlight("GitSignsCurrentLineBlame", colors.dark_1, "none", "none", "none")
 
     link_other_highlights()

--- a/lua/adwaita/light.lua
+++ b/lua/adwaita/light.lua
@@ -223,7 +223,7 @@ M.set = function()
 
     highlight('GitSignsAddLn', colors.green_6, colors.green_2, 'none', 'none')
     highlight('GitSignsChangeLn', colors.orange_5, colors.orange_1, 'none', 'none')
-	highlight("GitSignsCurrentLineBlame", colors.dark_1, "none", "none", "none")
+    highlight("GitSignsCurrentLineBlame", colors.dark_1, "none", "none", "none")
 
     link_other_highlights()
 end

--- a/lua/adwaita/light.lua
+++ b/lua/adwaita/light.lua
@@ -223,6 +223,9 @@ M.set = function()
 
     highlight('GitSignsAddLn', colors.green_6, colors.green_2, 'none', 'none')
     highlight('GitSignsChangeLn', colors.orange_5, colors.orange_1, 'none', 'none')
+
+	highlight("GitSignsCurrentLineBlame", colors.dark_1, "none", "none", "none")
+
     link_other_highlights()
 end
 


### PR DESCRIPTION
With cursorline, the GitSignsCurrentLineBlame was pretty much unreadable. So this sets it to use the same colors as comments. 

Before:
![Screenshot from 2023-05-09 02-17-28](https://user-images.githubusercontent.com/65873709/237038739-fefc55fa-00b7-4e99-a38b-0cb189781e93.png)

![Screenshot from 2023-05-09 02-17-01](https://user-images.githubusercontent.com/65873709/237038768-c0e7aea1-8a43-4a27-8280-4473d425374f.png)

After:
![Screenshot from 2023-05-09 02-17-55](https://user-images.githubusercontent.com/65873709/237038801-708ff501-0e4f-4b33-ac07-6abad940fe9c.png)

![Screenshot from 2023-05-09 02-18-17](https://user-images.githubusercontent.com/65873709/237038824-7d79ef31-b903-472f-a7ad-e65556898849.png)

